### PR TITLE
Restore the update to MovingDomes story trigger & content.

### DIFF
--- a/Code/2_MartianTribune.lua
+++ b/Code/2_MartianTribune.lua
@@ -368,3 +368,9 @@ function OnMsg.NewDay()
 		MartianTribune.Count.LastPublished = UICity.day
 	end
 end
+
+-- Fire a message that other mods can listen for to identify that the Martian Tribune
+-- Mod has been loaded and thus its functions are available.
+function OnMsg.ModsLoaded()
+	Msg("MartianTribuneModLoaded")
+end

--- a/Code/Stories_Colonist_MovingDomes.lua
+++ b/Code/Stories_Colonist_MovingDomes.lua
@@ -1,28 +1,37 @@
 local Key1 = "MovingDomes"
 
-local function CheckStory()
+local function CheckStory(colonist, old_dome, new_dome)
 	local MartianTribune = MartianTribune
-	local ColonistsHaveArrived = MartianTribune.ColonistsHaveArrived
 	local Sent = MartianTribune.Sent
-	local Domes = UICity.labels.Dome or empty_table
-	if not Sent[Key1] and ColonistsHaveArrived and #Domes > 2 then
-		local AddSocialStory = MartianTribuneMod.Functions.AddSocialPotentialStory
-		local Dome1 = table.rand(Domes)
-		local Dome2 = table.rand(Domes)
-		while Dome1 == Dome2 do
-			Dome2 = table.rand(Domes)
-		end
-		local Dome1Name = (Dome1 and Dome1.name) or T{9013691, "random dome <num>", num=1}
-		local Dome2Name = (Dome2 and Dome2.name) or T{9013691, "random dome <num>", num=2}
+	local MartianTribuneMod = MartianTribuneMod
+	local IsValidColonist = MartianTribuneMod.Functions.IsValidColonist
 
-		AddSocialStory({
+	if not Sent[Key1] and IsValidColonist(colonist) and IsValid(old_dome) and IsValid(new_dome) then
+		local AddStory = MartianTribuneMod.Functions.AddSocialPotentialStory
+		local ColonistName = colonist.name
+		local OldDomeName = old_dome.name or T{9013691, "random dome <num>", num=1}
+		local NewDomeName = new_dome.name or T{9013691, "random dome <num>", num=2}
+
+		AddStory({
 			key = Key1,
 			title = T{9013689, "The Rock Is Always Redder"},
-			story = T{9013690, "     In a recent survey performed by the Martian Tribune a number of citizens have expressed disappointment after moving to a new dome.  One citizen in particular hit the nail on the head saying, \"I always thought that moving from <MTMovingDome1> to <MTMovingDome2> would be a huge upgrade in lifestyle, but I've have found it to be basically the same as before. I guess it's true what they say: The rock is redder on the other side.\"", MTMovingDome1 = Dome1Name, MTMovingDome2 = Dome2Name}
+			story = T{9013690, "     In a recent survey performed by the Martian Tribune a number of citizens have expressed disappointment after moving to a new dome.  <ColonistName> hit the nail on the head saying, \"I always thought that moving from <MTMovingDome1> to <MTMovingDome2> would be a huge upgrade in lifestyle, but I've have found it to be basically the same as before. I guess it's true what they say: The rock is redder on the other side.\"", ColonistName = ColonistName, MTMovingDome1 = OldDomeName, MTMovingDome2 = NewDomeName}
 		})
 	end
 end
 
-function OnMsg.MartianTribuneCheckStories()
-	CheckStory()
+-- Trigger for walking to another dome
+local origTransportByFoot = Colonist.TransportByFoot
+function Colonist:TransportByFoot(...)
+	local old_dome = self.dome
+
+	if origTransportByFoot then
+		origTransportByFoot(self, ...)
+	end
+
+	local new_dome = self.dome
+	-- Make sure that they actually did move
+	if IsValid(old_dome) and IsValid(new_dome) and old_dome ~= new_dome then
+		CheckStory(self, old_dome, new_dome)
+	end
 end


### PR DESCRIPTION
This story had only just had its filename and content changed when we ran into the issue with the Mod Editor not handling subfolders properly. In the mess, the most recent change to the file got overwritten by the previous version by mistake, but the translation for the new version was kept.

This simply restores the lost change to this story so that it triggers when a colonist changes domes (via walking between them) rather than on a second dome being built.

This also restores firing the "MartianTribuneModLoaded" message that other mods can listen to for knowing when to add stories/set a Sponsor Name which also got lost by mistake. (Yay for git commit history - that showed what else needed checking!)