### PR TITLE
Bugfixes/mod integration

### DIFF
--- a/Code/2_MartianTribune.lua
+++ b/Code/2_MartianTribune.lua
@@ -371,6 +371,6 @@ end
 
 -- Fire a message that other mods can listen for to identify that the Martian Tribune
 -- Mod has been loaded and thus its functions are available.
-function OnMsg.ModsLoaded()
+function OnMsg.ModsReloaded()
 	Msg("MartianTribuneModLoaded", current_version)
 end

--- a/Code/Stories_Research_LowGTurbines.lua
+++ b/Code/Stories_Research_LowGTurbines.lua
@@ -3,9 +3,15 @@ local Key1 = "LowGTurbinesTech1"
 local Key2 = "LowGTurbinesTech2"
 
 local function CheckStory()
+	local MartianTribune = MartianTribune
 	local Sent = MartianTribune.Sent
+	local ColonistsHaveArrived = MartianTribune.ColonistsHaveArrived
 
-	if not Sent[Key1] and not Sent[Key2] and UICity.tech_status[TechId].researched ~= nil then
+	if not Sent[Key1]
+		and not Sent[Key2]
+		and ColonistsHaveArrived
+		and UICity.tech_status[TechId].researched ~= nil
+	then
 		local AddEngStory = MartianTribuneMod.Functions.AddEngFreeStory
 		local random_num = Random(1,2)
 

--- a/metadata.lua
+++ b/metadata.lua
@@ -1,11 +1,11 @@
 return PlaceObj('ModDef', {
 	'title', "The Martian Tribune",
 	'image', "Martian Tribune Preview Picture.png",
-	'last_changes', "More stories added.",
+	'last_changes', "Stories now have relevant in-game images associated and shown when applicable!",
 	'id', "lf1iELO",
 	'steam_id', "1376913896",
 	'author', "CheTranqui",
-	'version', 786,
+	'version', 787,
 	'lua_revision', 237920,
 	'code', {
 		"Code/1_Initialization.lua",
@@ -125,7 +125,7 @@ return PlaceObj('ModDef', {
 			language = "English",
 		},
 	},
-	'saved', 1542305931,
+	'saved', 1542655406,
 	'TagMissionSponsors', true,
 	'TagGameplay', true,
 	'TagResearch', true,


### PR DESCRIPTION
Update metadata for recent release.

Collection of small bugfixes identified as needed through testing mod integration.
* Wrong message name was being used for the trigger to tell other mods that Martian Tribune was present.
* LowGTurbines story needs the Colony Leader's name, so wait until ColonistsHaveArrived before triggering.